### PR TITLE
redirect to timeline index instead of show

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -34,7 +34,7 @@ class MediaController < ApplicationController
       p "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ IMAGE INSTANCE SAVED"
     end
 
-    redirect_to baby_event_path(@baby,@event)
+    redirect_to baby_events_path(@baby)
   end
 
   def medium_params


### PR DESCRIPTION
### Changelog
- Create medium now redirects to timeline index instead of event show page.
